### PR TITLE
Redirects user on endpoint "/" to appropriate front page

### DIFF
--- a/src/main/java/com/example/gruppe4bilabonnement/controllers/HomeController.java
+++ b/src/main/java/com/example/gruppe4bilabonnement/controllers/HomeController.java
@@ -14,9 +14,18 @@ public class HomeController {
     @Autowired
     private AdminService adminService;
 
+    // Redirect a user to their role's front page if they are logged on
     @GetMapping("/")
-    public String login() {
-        return "home/login";
+    public String login(HttpServletResponse response, @CookieValue(name = "employeeRole", defaultValue = "N/A") String cookieValue) {
+        Cookie cookie = new Cookie("employeeRole", cookieValue);
+        response.addCookie(cookie);
+
+        // Check is user is assigned a staff member's role and redirect them to their appropriate front page
+        if (!cookieValue.equals("N/A")) {
+            return "redirect:/employee_frontpage";
+        } else {
+            return "home/login";
+        }
     }
 
     // Attempt to find a user with given prompts

--- a/src/main/java/com/example/gruppe4bilabonnement/controllers/HomeController.java
+++ b/src/main/java/com/example/gruppe4bilabonnement/controllers/HomeController.java
@@ -17,13 +17,12 @@ public class HomeController {
     // Redirect a user to their role's front page if they are logged on
     @GetMapping("/")
     public String login(HttpServletResponse response, @CookieValue(name = "employeeRole", defaultValue = "N/A") String cookieValue) {
-        Cookie cookie = new Cookie("employeeRole", cookieValue);
-        response.addCookie(cookie);
-
         // Check is user is assigned a staff member's role and redirect them to their appropriate front page
         if (!cookieValue.equals("N/A")) {
             return "redirect:/employee_frontpage";
         } else {
+            Cookie cookie = new Cookie("employeeRole", cookieValue);
+            response.addCookie(cookie);
             return "home/login";
         }
     }


### PR DESCRIPTION
- Implemented `"N/A"` as a default cookie upon accessing the root endpoint`("/")`
- If a user is already logged on, the cookie value will not be affected and changed to `"N/A"` when accessing the root endpoint`("/")`

This is to prevent `MissingRequestCookieException` from being thrown when navigating to the admin's views without the necessary `"employeeRole"` cookie